### PR TITLE
Added Apache::Version module as mod_pagespeed dependency

### DIFF
--- a/Easy/Speed.pm
+++ b/Easy/Speed.pm
@@ -1,13 +1,13 @@
 package Cpanel::Easy::Speed;
 
 our $easyconfig = {
-  'name'      => 'mod_pagespeed (Author: Prajith)',
+  'name'      => 'mod_pagespeed',
   'url'       => 'http://www.prajith.in',
   'note'      => 'mod_pagespeed for Apache 2.x',
   'hastargz'  => 1,
   'ensurepkg' => [qw{rpm cpio}],
-  'depends'   => { 'optmods' => { 'Cpanel::Easy::Apache::Deflate' => 1, }, },
-  'implies'   => { 'Cpanel::Easy::Apache::Deflate' => 1, },
+  'depends'   => { 'optmods' => { 'Cpanel::Easy::Apache::Deflate' => 1, 'Cpanel::Easy::Apache::Version' => 1, }, },
+  'implies'   => { 'Cpanel::Easy::Apache::Deflate' => 1, 'Cpanel::Easy::Apache::Version' => 1, },
   'src_cd2'   => 'pagespeed/',
 
   'when_i_am_off' => sub {


### PR DESCRIPTION
Added Apache::Version module as mod_pagespeed dependency, otherwise easyapache will fail and you may get error like this 

!! Failed to generate a syntactically correct Apache configuration (/usr/local/apache/conf/httpd.conf.1380522903):
Configuration problem detected on line 42 of file /usr/local/apache/conf/httpd.conf.1380522903: : Syntax error on line 2 of /usr/local/apache/conf/pagespeed.conf: Cannot load modules/mod_version.so into server: /usr/local/apache/modules/mod_version.so: cannot open shared object file: No such file or directory
        --- /usr/local/apache/conf/httpd.conf.1380522903 ---
